### PR TITLE
Make user entity primary key accessible

### DIFF
--- a/src/Auth/FootprintAwareTrait.php
+++ b/src/Auth/FootprintAwareTrait.php
@@ -144,7 +144,9 @@ trait FootprintAwareTrait
      */
     protected function _getUserInstanceFromArray($user)
     {
-        return $this->_circumventEventManager('newEntity', [$user]);
+        $primaryKey = TableRegistry::get($this->_userModel)->primaryKey();
+        $options = ['accessibleFields' => [$primaryKey => true]];
+        return $this->_circumventEventManager('newEntity', [$user, $options]);
     }
 
     /**


### PR DESCRIPTION
When baking entities, the `$_accessible` property doesn't contain the primary key field.

In this situation, you cannot access `$this->_currentUser()->id` from the controller as it returns `null`.

This PR makes forces the primary key field to be accessible on the returned user instance.