### PR TITLE
Fix cases when identifier part of expression already

### DIFF
--- a/src/Model/Behavior/FootprintBehavior.php
+++ b/src/Model/Behavior/FootprintBehavior.php
@@ -89,7 +89,7 @@ class FootprintBehavior extends Behavior
                     return;
                 }
                 $alias = $this->_table->aliasField($field);
-                !$check && $check = preg_match('/' . $alias . '/', $expression->sql($query->valueBinder()));
+                !$check && $check = preg_match('/^' . $alias . '/', $expression->sql($query->valueBinder()));
             });
 
             if (!$check && $value = Hash::get((array)$options, $path)) {

--- a/src/Model/Behavior/FootprintBehavior.php
+++ b/src/Model/Behavior/FootprintBehavior.php
@@ -2,6 +2,7 @@
 namespace Muffin\Footprint\Model\Behavior;
 
 use ArrayObject;
+use Cake\Database\Expression\IdentifierExpression;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
@@ -80,7 +81,18 @@ class FootprintBehavior extends Behavior
 
         foreach (array_keys($config) as $field) {
             $path = $this->config('propertiesMap.' . $field);
-            if ($value = Hash::get((array)$options, $path)) {
+
+            $check = false;
+            $query->traverseExpressions(function ($expression) use (&$check, $field, $query) {
+                if ($expression instanceof IdentifierExpression) {
+                    !$check && $check = $expression->getIdentifier() === $field;
+                    return;
+                }
+                $alias = $this->_table->aliasField($field);
+                !$check && $check = preg_match('/' . $alias . '/', $expression->sql($query->valueBinder()));
+            });
+
+            if (!$check && $value = Hash::get((array)$options, $path)) {
                 $query->where([$this->_table->aliasField($field) => $value]);
             }
         }

--- a/tests/TestCase/Model/Behavior/FootprintBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/FootprintBehaviorTest.php
@@ -4,7 +4,6 @@ namespace Muffin\Footprint\Test\TestCase\Model\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
-use Muffin\Footprint\Model\Behavior\FootprintBehavior;
 
 class FootprintBehaviorTest extends TestCase
 {
@@ -65,6 +64,16 @@ class FootprintBehaviorTest extends TestCase
             ->first();
 
         $expected = ['id' => 3, 'title' => 'article 3', 'created_by' => 2, 'modified_by' => 1];
+        $this->assertSame($expected, $result);
+
+        // Test to show value of "id" is not used from footprint if
+        // "Articles.created_by" is already set in condition.
+        $result = $this->Table->find('all', ['_footprint' => $this->footprint])
+            ->where(['Articles.created_by' => 1])
+            ->hydrate(false)
+            ->first();
+
+        $expected = ['id' => 1, 'title' => 'article 1', 'created_by' => 1, 'modified_by' => 1];
         $this->assertSame($expected, $result);
     }
 


### PR DESCRIPTION
Sometimes, the field being used by the behavior (on `Model.beforeFind`) is already part of the find query which would cause an error or at the very least, override the original intention.

Still missing tests to catch it in the future and probably split that into its own method - but first I'd like confirmation that this looks somewhat close to the final solution.

(ps: it works)