### PR TITLE
Fixed migrate command error out when "$this->Auth" returns false

### DIFF
--- a/src/Auth/FootprintAwareTrait.php
+++ b/src/Auth/FootprintAwareTrait.php
@@ -97,7 +97,7 @@ trait FootprintAwareTrait
      */
     protected function _setCurrentUser($user = null)
     {
-        if (!$user && !$user = $this->Auth->user()) {
+        if (!$this->Auth || (!$user && !$user = $this->Auth->user())) {
             return false;
         }
 

--- a/tests/TestCase/Auth/FootprintAwareTraitTest.php
+++ b/tests/TestCase/Auth/FootprintAwareTraitTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Muffin\Footprint\Test\TestCase\Model\Behavior;
 
+use Cake\Event\Event;
 use Cake\Event\EventManager;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use TestApp\Controller\ArticlesController;
@@ -49,5 +51,18 @@ class FootprintAwareTraitTest extends TestCase
         $this->controller->Auth->identify();
 
         $this->assertNotNull($this->controller->getCurrentUserInstance());
+    }
+
+    /**
+     * Tests for the case where the Auth component is not loaded, but FootprintAwareTrait is.
+     *
+     * @return void
+     */
+    public function testNoAuthRegression()
+    {
+        unset($this->controller->Auth);
+        $this->controller->footprint(new Event('Model.initialize', new Table(), ['id' => 1]));
+
+        $this->assertNull($this->controller->getCurrentUserInstance());
     }
 }


### PR DESCRIPTION
Added check to be sure "$this->Auth" is not "false" which causes the "migrate" command to error out...error description below;

Fatal error: Call to a member function user() on boolean in vendor/muffin/footprint/src/Auth/FootprintAwareTrait.php on line 100