### PR TITLE
Make user available in beforeValidate callback too

### DIFF
--- a/src/Event/FootprintListener.php
+++ b/src/Event/FootprintListener.php
@@ -20,6 +20,7 @@ class FootprintListener implements EventListenerInterface
         'events' => [
             'Model.beforeFind' => -100,
             'Model.beforeSave' => -100,
+            'Model.beforeValidate' => -100,
         ],
         'optionKey' => '_footprint',
     ];

--- a/tests/TestCase/Event/FootprintListenerTest.php
+++ b/tests/TestCase/Event/FootprintListenerTest.php
@@ -19,6 +19,7 @@ class FootprintListenerTest extends TestCase
         $expected = [
             'Model.beforeSave' => ['priority' => -100, 'callable' => 'handleEvent'],
             'Model.beforeFind' => ['priority' => -100, 'callable' => 'handleEvent'],
+            'Model.beforeValidate' => ['priority' => -100, 'callable' => 'handleEvent'],
         ];
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
This makes is possible to setup validators which require user info.

Had someone on IRC have this use case. While the events for the listener are configurable there's no way to make `FootprintAwareTrait::footprint()` pass required config to listener constructor.