### PR TITLE
Fix for Ambiguous SQL Queries

### DIFF
--- a/src/Model/Behavior/FootprintBehavior.php
+++ b/src/Model/Behavior/FootprintBehavior.php
@@ -81,7 +81,7 @@ class FootprintBehavior extends Behavior
         foreach (array_keys($config) as $field) {
             $path = $this->config('propertiesMap.' . $field);
             $query->where([
-                $field => current(Hash::extract((array)$options, $path))
+                $this->_table->aliasField($field) => current(Hash::extract((array)$options, $path))
             ]);
         }
     }


### PR DESCRIPTION
This change causes the Model name to attach to field names preventing database ambiguous errors. For example group_id becomes Users.group_id.

This fixes makes it useful for multi-tenant applications.