### PR TITLE
Sets Model.initialize in trait __construct method

### DIFF
--- a/src/Auth/FootprintAwareTrait.php
+++ b/src/Auth/FootprintAwareTrait.php
@@ -8,7 +8,6 @@ use Cake\Network\Response;
 use Cake\ORM\TableRegistry;
 use Muffin\Footprint\Event\FootprintListener;
 
-
 trait FootprintAwareTrait
 {
 

--- a/src/Auth/FootprintAwareTrait.php
+++ b/src/Auth/FootprintAwareTrait.php
@@ -3,8 +3,11 @@ namespace Muffin\Footprint\Auth;
 
 use Cake\Event\Event;
 use Cake\Event\EventManager;
+use Cake\Network\Request;
+use Cake\Network\Response;
 use Cake\ORM\TableRegistry;
 use Muffin\Footprint\Event\FootprintListener;
+
 
 trait FootprintAwareTrait
 {
@@ -31,14 +34,31 @@ trait FootprintAwareTrait
     protected $_listener;
 
     /**
+     * Constructor.
+     *
+     * Sets Model.initialize event listener before any model can get initialized (in components, for instance)
+     *
+     * @param \Cake\Network\Request|null $request Request object for this controller. Can be null for testing,
+     *   but expect that features that use the request parameters will not work.
+     * @param \Cake\Network\Response|null $response Response object for this controller.
+     * @param string|null $name Override the name useful in testing when using mocks.
+     * @param \Cake\Event\EventManager|null $eventManager The event manager. Defaults to a new instance.
+     * @param \Cake\Controller\ComponentRegistry|null $components The component registry. Defaults to a new instance.
+     */
+    public function __construct(Request $request = null, Response $response = null, $name = null, $eventManager = null, $components = null)
+    {
+        EventManager::instance()->on('Model.initialize', [$this, 'footprint']);
+
+        parent::__construct($request, $response, $name, $eventManager, $components);
+    }
+
+    /**
      * Events this trait is interested in.
      *
      * @return array
      */
     public function implementedEvents()
     {
-        EventManager::instance()->on('Model.initialize', [$this, 'footprint']);
-
         return parent::implementedEvents() + ['Auth.afterIdentify' => 'footprint'];
     }
 

--- a/tests/Fixture/AuthorsFixture.php
+++ b/tests/Fixture/AuthorsFixture.php
@@ -1,0 +1,37 @@
+<?php
+namespace Muffin\Footprint\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class AuthorsFixture extends TestFixture
+{
+    public $table = 'authors';
+
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'name' => ['type' => 'string', 'length' => 255],
+        'created_by' => ['type' => 'integer'],
+        'modified_by' => ['type' => 'integer'],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ];
+
+    public $records = [
+        [
+            'name' => 'author 1',
+            'created_by' => 1,
+            'modified_by' => 1,
+        ],
+        [
+            'name' => 'author 2',
+            'created_by' => 1,
+            'modified_by' => 2,
+        ],
+        [
+            'name' => 'author 3',
+            'created_by' => 2,
+            'modified_by' => 1,
+        ],
+    ];
+}

--- a/tests/test_app/TestApp/Controller/ArticlesController.php
+++ b/tests/test_app/TestApp/Controller/ArticlesController.php
@@ -2,12 +2,27 @@
 namespace TestApp\Controller;
 
 use Cake\Controller\Controller;
+use Cake\ORM\TableRegistry;
 use Muffin\Footprint\Auth\FootprintAwareTrait;
 
+/**
+ * @property \Cake\ORM\Table Authors
+ */
 class ArticlesController extends Controller
 {
     use FootprintAwareTrait;
 
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->Authors = TableRegistry::get('Muffin/Footprint.Authors');
+        $this->Authors->addBehavior('Muffin/Footprint.Footprint');
+    }
+    
+    /**
+     * @return \Cake\ORM\Entity
+     */
     public function getCurrentUserInstance()
     {
         return $this->_currentUserInstance;


### PR DESCRIPTION
A problem was occurring when models that have Footprint behaviour were initialised in component, before Footprint Model.initialize listener was getting set.