### PR TITLE
Prepare the plugin for CakePHP 3.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "source": "https://github.com/usemuffin/footprint"
     },
     "require-dev": {
-        "cakephp/cakephp": "~3.0",
+        "cakephp/cakephp": "3.6.0-beta1",
         "cakephp/cakephp-codesniffer": "2.*",
         "phpunit/phpunit": "<6.0"
     },

--- a/src/Auth/FootprintAwareTrait.php
+++ b/src/Auth/FootprintAwareTrait.php
@@ -57,13 +57,13 @@ trait FootprintAwareTrait
             $this->_listener = new FootprintListener($this->_getCurrentUser());
         }
 
-        if ($event->name() === 'Auth.afterIdentify') {
-            $this->_listener->setUser($this->_getCurrentUser($event->data[0]));
+        if ($event->getName() === 'Auth.afterIdentify') {
+            $this->_listener->setUser($this->_getCurrentUser($event->getData(0)));
 
             return;
         }
 
-        $event->subject()->eventManager()->attach($this->_listener);
+        $event->getSubject()->getEventManager()->on($this->_listener);
     }
 
     /**
@@ -161,7 +161,7 @@ trait FootprintAwareTrait
      */
     protected function _checkUserInstanceOf($user)
     {
-        $entityClass = $this->_circumventEventManager('entityClass');
+        $entityClass = $this->_circumventEventManager('getEntityClass');
 
         return $user instanceof $entityClass;
     }

--- a/src/Event/FootprintListener.php
+++ b/src/Event/FootprintListener.php
@@ -41,7 +41,7 @@ class FootprintListener implements EventListenerInterface
      */
     public function __construct(Entity $user = null, array $config = [])
     {
-        $this->config($config);
+        $this->setConfig($config);
         $this->_currentUser = $user;
     }
 
@@ -54,7 +54,7 @@ class FootprintListener implements EventListenerInterface
             $callable = 'handleEvent';
 
             return compact('callable', 'priority');
-        }, $this->config('events'));
+        }, $this->getConfig('events'));
     }
 
     /**
@@ -78,7 +78,7 @@ class FootprintListener implements EventListenerInterface
      */
     public function handleEvent(Event $event, $ormObject, $options)
     {
-        $key = $this->config('optionKey');
+        $key = $this->getConfig('optionKey');
         if (empty($options[$key]) && !empty($this->_currentUser)) {
             $options[$key] = $this->_currentUser;
         }

--- a/src/Model/Behavior/FootprintBehavior.php
+++ b/src/Model/Behavior/FootprintBehavior.php
@@ -37,10 +37,10 @@ class FootprintBehavior extends Behavior
     public function initialize(array $config)
     {
         if (isset($config['events'])) {
-            $this->config('events', $config['events'], false);
+            $this->setConfig('events', $config['events'], false);
         }
 
-        $config = $this->config();
+        $config = $this->getConfig();
 
         foreach ($config['events'] as $name => $options) {
             $options = Hash::normalize((array)$options);
@@ -65,7 +65,7 @@ class FootprintBehavior extends Behavior
             }
         }
 
-        $this->config('propertiesMap', $config['propertiesMap'], false);
+        $this->setConfig('propertiesMap', $config['propertiesMap'], false);
     }
 
     /**
@@ -93,7 +93,7 @@ class FootprintBehavior extends Behavior
      */
     public function dispatch(Event $event, $data, ArrayObject $options)
     {
-        $eventName = $event->name();
+        $eventName = $event->getName();
         if (empty($this->_config['events'][$eventName])) {
             return;
         }
@@ -129,7 +129,7 @@ class FootprintBehavior extends Behavior
     protected function _injectConditions(Query $query, ArrayObject $options, array $fields)
     {
         foreach (array_keys($fields) as $field) {
-            $path = $this->config('propertiesMap.' . $field);
+            $path = $this->getConfig('propertiesMap.' . $field);
 
             $check = false;
             $query->traverseExpressions(function ($expression) use (&$check, $field, $query) {
@@ -139,7 +139,7 @@ class FootprintBehavior extends Behavior
                     return;
                 }
                 $alias = $this->_table->aliasField($field);
-                !$check && $check = preg_match('/^' . $alias . '/', $expression->sql($query->valueBinder()));
+                !$check && $check = preg_match('/^' . $alias . '/', $expression->sql($query->getValueBinder()));
             });
 
             if (!$check && $value = Hash::get((array)$options, $path)) {
@@ -168,7 +168,7 @@ class FootprintBehavior extends Behavior
                 ));
             }
 
-            if ($entity->dirty($field)) {
+            if ($entity->isDirty($field)) {
                 continue;
             }
 
@@ -178,7 +178,7 @@ class FootprintBehavior extends Behavior
             ) {
                 $entity->set(
                     $field,
-                    current(Hash::extract((array)$options, $this->config('propertiesMap.' . $field)))
+                    current(Hash::extract((array)$options, $this->getConfig('propertiesMap.' . $field)))
                 );
             }
         }

--- a/tests/TestCase/Auth/FootprintAwareTraitTest.php
+++ b/tests/TestCase/Auth/FootprintAwareTraitTest.php
@@ -19,11 +19,13 @@ class FootprintAwareTraitTest extends TestCase
         $this->controller = new ArticlesController(null, null, null, new EventManager());
 
         $this->controller->loadComponent('Auth');
-        $this->controller->Auth->request->data = [
+
+        $this->controller->Auth->request = $this->controller->Auth->request->withParsedBody([
             'username' => 'mariano',
             'password' => 'cake'
-        ];
-        $this->controller->Auth->config('authenticate', ['Form']);
+        ]);
+
+        $this->controller->Auth->setConfig('authenticate', ['Form']);
 
         $Users = TableRegistry::get('Users');
         $Users->updateAll(['password' => password_hash('cake', PASSWORD_BCRYPT)], []);
@@ -60,7 +62,7 @@ class FootprintAwareTraitTest extends TestCase
 
         $user = $this->controller->getCurrentUserInstance();
         $this->assertInstanceOf('\Cake\ORM\Entity', $user);
-        $this->assertTrue($user->accessible('id'));
+        $this->assertTrue($user->isAccessible('id'));
         $this->assertTrue(isset($user->id));
     }
 

--- a/tests/TestCase/Model/Behavior/FootprintBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/FootprintBehaviorTest.php
@@ -58,7 +58,7 @@ class FootprintBehaviorTest extends TestCase
     public function testFind()
     {
         $result = $this->Table->find('all', ['_footprint' => $this->footprint])
-            ->hydrate(false)
+            ->enableHydration(false)
             ->first();
 
         $expected = ['id' => 3, 'title' => 'article 3', 'created_by' => 2, 'modified_by' => 1];
@@ -68,7 +68,7 @@ class FootprintBehaviorTest extends TestCase
         // "Articles.created_by" is already set in condition.
         $result = $this->Table->find('all', ['_footprint' => $this->footprint])
             ->where(['Articles.created_by' => 1])
-            ->hydrate(false)
+            ->enableHydration(false)
             ->first();
 
         $expected = ['id' => 1, 'title' => 'article 1', 'created_by' => 1, 'modified_by' => 1];
@@ -83,7 +83,7 @@ class FootprintBehaviorTest extends TestCase
      */
     public function testInjectEntityException()
     {
-        $this->Table->behaviors()->Footprint->config(
+        $this->Table->behaviors()->Footprint->setConfig(
             'events',
             [
                 'Model.beforeSave' => [
@@ -102,8 +102,8 @@ class FootprintBehaviorTest extends TestCase
     public function testDispatchException()
     {
         $behavior = $this->Table->behaviors()->Footprint;
-        $behavior->config('events', ['Model.beforeMarshal' => ['modified_by']]);
-        $this->Table->eventManager()->on('Model.beforeMarshal', [$behavior, 'dispatch']);
+        $behavior->setConfig('events', ['Model.beforeMarshal' => ['modified_by']]);
+        $this->Table->getEventManager()->on('Model.beforeMarshal', [$behavior, 'dispatch']);
         $entity = $this->Table->newEntity([]);
     }
 }


### PR DESCRIPTION
Like I did for the TrashBehavior plugin, this PR aims to prepare the plugin for CakePHP 3.6.0 and removes all deprecation notices.

This PR is targetting `master` right now.