### PR TITLE
Fix notice for undefined `_currentUserViewVar`

### DIFF
--- a/src/Auth/FootprintAwareTrait.php
+++ b/src/Auth/FootprintAwareTrait.php
@@ -78,6 +78,7 @@ trait FootprintAwareTrait
         $this->_setCurrentUser($user);
 
         if (!$this->_currentUserInstance &&
+            isset($this->_currentUserViewVar) &&
             !empty($this->viewVars[$this->_currentUserViewVar])
         ) {
             $this->_currentUserInstance = $this->viewVars[$this->_currentUserViewVar];


### PR DESCRIPTION
Since Cake 3.6.12 trying to access non existent controller property throws error.
Fixes #55.