### PR TITLE
[2.0.0-beta] Updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ class AppController extends Controller
 
     protected function _setCurrentUser($user = null)
     {
-        if (!$user) {
+        if (!$user && $this->request->getAttribute('identity')) {
             $user = $this->request->getAttribute('identity')->getOriginalData();
         }
 


### PR DESCRIPTION
When using `cakephp/authentication` plugin, an error is outputted if the user is not logged in. `Call to a member function getOriginalData() on null` updated example to include a check for the identity on the request.