### PR TITLE
Call the correct interface method

### DIFF
--- a/src/Auth/FootprintAwareTrait.php
+++ b/src/Auth/FootprintAwareTrait.php
@@ -106,7 +106,7 @@ trait FootprintAwareTrait
         if ($user === null && !empty($this->Authentication)) {
             $identity = $this->Authentication->getIdentity();
             if ($identity) {
-                $user = $identity->getData();
+                $user = $identity->getOriginalData();
             }
         }
 


### PR DESCRIPTION
`getData()` does not exist on the authentication `IdentityInterface`. The correct method is `getOriginalData()`